### PR TITLE
Fix catalogue date to have zero prefix for single digit dates

### DIFF
--- a/alkoloader.js
+++ b/alkoloader.js
@@ -61,7 +61,7 @@ class AlkoLoader {
   }
 
   formatDate(date) {
-    return date.format('D.M.YYYY');
+    return date.format('DD.MM.YYYY');
   }
 }
 


### PR DESCRIPTION
Change the date format in the name of the catalogue to be fetched so that single-digit days have a zero prefix (as the Alko API seems to expect this).