### PR TITLE
Use all search terms separately in search

### DIFF
--- a/app.js
+++ b/app.js
@@ -49,9 +49,14 @@ app.use('/alldata', function(req, res, next) {
   res.send(JSON.stringify(loadedData));
 });
 
-function matches(searchFor, searchFrom) {
-  const from = searchFrom || '';
-  return from.toLowerCase().indexOf(searchFor.toLowerCase()) !== -1;
+function matches(searchTerms, searchFrom) {
+  const haystack = searchFrom.join('').toLowerCase();
+  if (!haystack) {
+    return false;
+  }
+
+  const needles = searchTerms.split(/\W/);
+  return needles.reduce((acc, searchTerm) => { return acc && haystack.indexOf(searchTerm.toLowerCase()) !== -1 }, true);
 }
 
 app.use('/data', function(req, res, next) {
@@ -64,10 +69,7 @@ app.use('/data', function(req, res, next) {
 
   var filteredData = loadedData.filter(data => {
     // console.log('Checking', data);
-    if (data.nimi || data.tyyppi) {
-      return matches(searchTerms, data.nimi) || matches(searchTerms, data.tyyppi);
-    }
-    return false;
+    return matches(searchTerms, [data.nimi, data.tyyppi]);
   });
 
   res.send(JSON.stringify(filteredData));


### PR DESCRIPTION
All words in search terms are now used in search separately so one can search for drink results using several partial matches.

E.g. "wolfbe noir" matches "Wolfberger La Louve Pinot Noir 2015" and "my konj" returns all Rémy Martin cognacs.