### PR TITLE
Dev proxy

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,2 +1,2 @@
 .DS_STORE
-node_modules
+client/node_modules

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This app downloads and parses that form and serves it in a searchable form.
 
 Currently the server and client are built separate, and there is a clunky way to run the server and keep the client updated.
 
-Open a terminal in the client-directory and run `npm run dev`.
+Open a terminal in the client-directory and run `npm run start`.
 
 Open a second terminal in the main directory and run `npm run dev`.
 

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9,12 +9,6 @@
       "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
       "integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4="
     },
-    "abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
-      "dev": true
-    },
     "accepts": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
@@ -63,7 +57,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
-      "dev": true,
       "requires": {
         "acorn": "3.3.0"
       },
@@ -71,8 +64,7 @@
         "acorn": {
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
-          "dev": true
+          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
         }
       }
     },
@@ -1489,7 +1481,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-      "dev": true,
       "requires": {
         "callsites": "0.2.0"
       }
@@ -1497,8 +1488,7 @@
     "callsites": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
-      "dev": true
+      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo="
     },
     "camel-case": {
       "version": "3.0.0",
@@ -1643,8 +1633,7 @@
     "circular-json": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
-      "dev": true
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A=="
     },
     "clap": {
       "version": "1.2.3",
@@ -1822,7 +1811,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-      "dev": true,
       "requires": {
         "inherits": "2.0.3",
         "readable-stream": "2.3.3",
@@ -1873,8 +1861,7 @@
     "contains-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
-      "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
-      "dev": true
+      "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo="
     },
     "content-disposition": {
       "version": "0.5.2",
@@ -2023,12 +2010,6 @@
         "randombytes": "2.0.5",
         "randomfill": "1.0.3"
       }
-    },
-    "crypto-random-string": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
-      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
-      "dev": true
     },
     "css-color-names": {
       "version": "0.0.4",
@@ -2461,7 +2442,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
       "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
-      "dev": true,
       "requires": {
         "esutils": "2.0.2",
         "isarray": "1.0.0"
@@ -2558,12 +2538,6 @@
       "requires": {
         "readable-stream": "2.3.3"
       }
-    },
-    "duplexer3": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
-      "dev": true
     },
     "ecc-jsbn": {
       "version": "0.1.1",
@@ -2913,7 +2887,6 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.1.tgz",
       "integrity": "sha512-yUtXS15gIcij68NmXmP9Ni77AQuCN0itXbCc/jWd8C6/yKZaSNXicpC8cgvjnxVdmfsosIXrjpzFq7GcDryb6A==",
-      "dev": true,
       "requires": {
         "debug": "2.6.9",
         "resolve": "1.5.0"
@@ -2935,7 +2908,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz",
       "integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
-      "dev": true,
       "requires": {
         "debug": "2.6.9",
         "pkg-dir": "1.0.0"
@@ -2945,7 +2917,6 @@
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true,
           "requires": {
             "path-exists": "2.1.0",
             "pinkie-promise": "2.0.1"
@@ -2955,7 +2926,6 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
           "requires": {
             "pinkie-promise": "2.0.1"
           }
@@ -2964,7 +2934,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
           "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
-          "dev": true,
           "requires": {
             "find-up": "1.1.2"
           }
@@ -3099,10 +3068,18 @@
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
       "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
-      "dev": true,
       "requires": {
         "esrecurse": "4.2.0",
         "estraverse": "4.2.0"
+      }
+    },
+    "espree": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.2.tgz",
+      "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
+      "requires": {
+        "acorn": "5.2.1",
+        "acorn-jsx": "3.0.1"
       }
     },
     "esprima": {
@@ -3114,7 +3091,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
       "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
-      "dev": true,
       "requires": {
         "estraverse": "4.2.0"
       }
@@ -3150,21 +3126,6 @@
       "requires": {
         "d": "1.0.0",
         "es5-ext": "0.10.35"
-      }
-    },
-    "event-stream": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
-      "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
-      "dev": true,
-      "requires": {
-        "duplexer": "0.1.1",
-        "from": "0.1.7",
-        "map-stream": "0.1.0",
-        "pause-stream": "0.0.11",
-        "split": "0.3.3",
-        "stream-combiner": "0.0.4",
-        "through": "2.3.8"
       }
     },
     "eventemitter3": {
@@ -3390,7 +3351,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
-      "dev": true,
       "requires": {
         "flat-cache": "1.3.0",
         "object-assign": "4.1.1"
@@ -3476,7 +3436,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
       "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
-      "dev": true,
       "requires": {
         "circular-json": "0.3.3",
         "del": "2.2.2",
@@ -3531,12 +3490,6 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
-    },
-    "from": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
-      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
-      "dev": true
     },
     "fs-extra": {
       "version": "3.0.1",
@@ -4346,8 +4299,7 @@
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
-      "dev": true
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
     },
     "get-caller-file": {
       "version": "1.0.2",
@@ -4400,15 +4352,6 @@
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "requires": {
         "is-glob": "2.0.1"
-      }
-    },
-    "global-dirs": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.0.tgz",
-      "integrity": "sha1-ENNAOeDfBCcuJizyQiT3IJQ0308=",
-      "dev": true,
-      "requires": {
-        "ini": "1.3.4"
       }
     },
     "global-modules": {
@@ -4874,20 +4817,7 @@
     "ignore": {
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
-      "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
-      "dev": true
-    },
-    "ignore-by-default": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
-      "integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk=",
-      "dev": true
-    },
-    "import-lazy": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
-      "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
-      "dev": true
+      "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA=="
     },
     "imurmurhash": {
       "version": "0.1.4",
@@ -5117,16 +5047,6 @@
         "is-extglob": "1.0.0"
       }
     },
-    "is-installed-globally": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
-      "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
-      "dev": true,
-      "requires": {
-        "global-dirs": "0.1.0",
-        "is-path-inside": "1.0.0"
-      }
-    },
     "is-npm": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
@@ -5203,7 +5123,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
       "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
-      "dev": true,
       "requires": {
         "tryit": "1.0.3"
       }
@@ -5946,66 +5865,10 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
       "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
     },
-    "lodash._baseassign": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-      "dev": true,
-      "requires": {
-        "lodash._basecopy": "3.0.1",
-        "lodash.keys": "3.1.2"
-      }
-    },
-    "lodash._basecopy": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
-      "dev": true
-    },
-    "lodash._bindcallback": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-      "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
-      "dev": true
-    },
-    "lodash._createassigner": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
-      "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
-      "dev": true,
-      "requires": {
-        "lodash._bindcallback": "3.0.1",
-        "lodash._isiterateecall": "3.0.9",
-        "lodash.restparam": "3.6.1"
-      }
-    },
-    "lodash._getnative": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
-      "dev": true
-    },
-    "lodash._isiterateecall": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
-      "dev": true
-    },
     "lodash._reinterpolate": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
-    },
-    "lodash.assign": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
-      "integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo=",
-      "dev": true,
-      "requires": {
-        "lodash._baseassign": "3.2.0",
-        "lodash._createassigner": "3.1.1",
-        "lodash.keys": "3.1.2"
-      }
     },
     "lodash.camelcase": {
       "version": "4.3.0",
@@ -6015,47 +5878,17 @@
     "lodash.cond": {
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz",
-      "integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU=",
-      "dev": true
+      "integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU="
     },
     "lodash.defaults": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
       "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
     },
-    "lodash.isarguments": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
-      "dev": true
-    },
-    "lodash.isarray": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
-      "dev": true
-    },
-    "lodash.keys": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "dev": true,
-      "requires": {
-        "lodash._getnative": "3.9.1",
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
-      }
-    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
-    },
-    "lodash.restparam": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-      "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
-      "dev": true
     },
     "lodash.template": {
       "version": "4.4.0",
@@ -6157,12 +5990,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
       "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
-    },
-    "map-stream": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
-      "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
-      "dev": true
     },
     "math-expression-evaluator": {
       "version": "1.2.17",
@@ -6460,201 +6287,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz",
       "integrity": "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8="
-    },
-    "nodemon": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.12.1.tgz",
-      "integrity": "sha1-mWpW3EnZ8Wu/G3ik3gjxNjSzh40=",
-      "dev": true,
-      "requires": {
-        "chokidar": "1.7.0",
-        "debug": "2.6.9",
-        "es6-promise": "3.3.1",
-        "ignore-by-default": "1.0.1",
-        "lodash.defaults": "3.1.2",
-        "minimatch": "3.0.4",
-        "ps-tree": "1.1.0",
-        "touch": "3.1.0",
-        "undefsafe": "0.0.3",
-        "update-notifier": "2.3.0"
-      },
-      "dependencies": {
-        "ansi-align": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
-          "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
-          "dev": true,
-          "requires": {
-            "string-width": "2.1.1"
-          }
-        },
-        "boxen": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.2.2.tgz",
-          "integrity": "sha1-Px1AMsMP/qnUsCwyLq8up0HcvOU=",
-          "dev": true,
-          "requires": {
-            "ansi-align": "2.0.0",
-            "camelcase": "4.1.0",
-            "chalk": "2.3.0",
-            "cli-boxes": "1.0.0",
-            "string-width": "2.1.1",
-            "term-size": "1.2.0",
-            "widest-line": "1.0.0"
-          }
-        },
-        "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
-          }
-        },
-        "configstore": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.1.tgz",
-          "integrity": "sha512-5oNkD/L++l0O6xGXxb1EWS7SivtjfGQlRyxJsYgE0Z495/L81e2h4/d3r969hoPXuFItzNOKMtsXgYG4c7dYvw==",
-          "dev": true,
-          "requires": {
-            "dot-prop": "4.2.0",
-            "graceful-fs": "4.1.11",
-            "make-dir": "1.1.0",
-            "unique-string": "1.0.0",
-            "write-file-atomic": "2.3.0",
-            "xdg-basedir": "3.0.0"
-          }
-        },
-        "dot-prop": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
-          "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
-          "dev": true,
-          "requires": {
-            "is-obj": "1.0.1"
-          }
-        },
-        "es6-promise": {
-          "version": "3.3.1",
-          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
-          "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM=",
-          "dev": true
-        },
-        "got": {
-          "version": "6.7.1",
-          "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
-          "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
-          "dev": true,
-          "requires": {
-            "create-error-class": "3.0.2",
-            "duplexer3": "0.1.4",
-            "get-stream": "3.0.0",
-            "is-redirect": "1.0.0",
-            "is-retry-allowed": "1.1.0",
-            "is-stream": "1.1.0",
-            "lowercase-keys": "1.0.0",
-            "safe-buffer": "5.1.1",
-            "timed-out": "4.0.1",
-            "unzip-response": "2.0.1",
-            "url-parse-lax": "1.0.0"
-          }
-        },
-        "latest-version": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
-          "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
-          "dev": true,
-          "requires": {
-            "package-json": "4.0.1"
-          }
-        },
-        "lodash.defaults": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-3.1.2.tgz",
-          "integrity": "sha1-xzCLGNv4vJNy1wGnNJPGEZK9Liw=",
-          "dev": true,
-          "requires": {
-            "lodash.assign": "3.2.0",
-            "lodash.restparam": "3.6.1"
-          }
-        },
-        "package-json": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
-          "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
-          "dev": true,
-          "requires": {
-            "got": "6.7.1",
-            "registry-auth-token": "3.3.1",
-            "registry-url": "3.1.0",
-            "semver": "5.4.1"
-          }
-        },
-        "timed-out": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-          "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
-          "dev": true
-        },
-        "unzip-response": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
-          "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
-          "dev": true
-        },
-        "update-notifier": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.3.0.tgz",
-          "integrity": "sha1-TognpruRUUCrCTVZ1wFOPruDdFE=",
-          "dev": true,
-          "requires": {
-            "boxen": "1.2.2",
-            "chalk": "2.3.0",
-            "configstore": "3.1.1",
-            "import-lazy": "2.1.0",
-            "is-installed-globally": "0.1.0",
-            "is-npm": "1.0.0",
-            "latest-version": "3.1.0",
-            "semver-diff": "2.1.0",
-            "xdg-basedir": "3.0.0"
-          }
-        },
-        "write-file-atomic": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
-          "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "imurmurhash": "0.1.4",
-            "signal-exit": "3.0.2"
-          }
-        },
-        "xdg-basedir": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
-          "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
-          "dev": true
-        }
-      }
-    },
-    "nopt": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
-      "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
-      "dev": true,
-      "requires": {
-        "abbrev": "1.1.1"
-      }
     },
     "normalize-package-data": {
       "version": "2.4.0",
@@ -7021,15 +6653,6 @@
         "pinkie-promise": "2.0.1"
       }
     },
-    "pause-stream": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
-      "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
-      "dev": true,
-      "requires": {
-        "through": "2.3.8"
-      }
-    },
     "pbkdf2": {
       "version": "3.0.14",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.14.tgz",
@@ -7072,6 +6695,11 @@
       "requires": {
         "find-up": "2.1.0"
       }
+    },
+    "pluralize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-4.0.0.tgz",
+      "integrity": "sha1-WbcIwcAZCi9pLxx2GMRGsFL9F2I="
     },
     "portfinder": {
       "version": "1.0.13",
@@ -8291,8 +7919,7 @@
     "progress": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
-      "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
-      "dev": true
+      "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8="
     },
     "promise": {
       "version": "7.3.1",
@@ -8325,15 +7952,6 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
       "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo="
-    },
-    "ps-tree": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.1.0.tgz",
-      "integrity": "sha1-tCGyQUDWID8e08dplrRCewjowBQ=",
-      "dev": true,
-      "requires": {
-        "event-stream": "3.3.4"
-      }
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -8547,9 +8165,13 @@
         "chalk": "1.1.3",
         "css-loader": "0.28.4",
         "dotenv": "4.0.0",
+        "eslint": "4.4.1",
         "eslint-config-react-app": "2.0.1",
         "eslint-loader": "1.9.0",
+        "eslint-plugin-flowtype": "2.35.0",
+        "eslint-plugin-import": "2.7.0",
         "eslint-plugin-jsx-a11y": "5.1.1",
+        "eslint-plugin-react": "7.1.0",
         "extract-text-webpack-plugin": "3.0.0",
         "file-loader": "0.11.2",
         "fs-extra": "3.0.1",
@@ -8570,6 +8192,128 @@
         "whatwg-fetch": "2.0.3"
       },
       "dependencies": {
+        "eslint": {
+          "version": "4.4.1",
+          "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.4.1.tgz",
+          "integrity": "sha1-mc1+r8/8ov+Zpcj18qR01jZLS9M=",
+          "requires": {
+            "ajv": "5.3.0",
+            "babel-code-frame": "6.26.0",
+            "chalk": "1.1.3",
+            "concat-stream": "1.6.0",
+            "cross-spawn": "5.1.0",
+            "debug": "2.6.9",
+            "doctrine": "2.0.0",
+            "eslint-scope": "3.7.1",
+            "espree": "3.5.2",
+            "esquery": "1.0.0",
+            "estraverse": "4.2.0",
+            "esutils": "2.0.2",
+            "file-entry-cache": "2.0.0",
+            "functional-red-black-tree": "1.0.1",
+            "glob": "7.1.2",
+            "globals": "9.18.0",
+            "ignore": "3.3.7",
+            "imurmurhash": "0.1.4",
+            "inquirer": "3.3.0",
+            "is-resolvable": "1.0.0",
+            "js-yaml": "3.10.0",
+            "json-stable-stringify": "1.0.1",
+            "levn": "0.3.0",
+            "lodash": "4.17.4",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
+            "natural-compare": "1.4.0",
+            "optionator": "0.8.2",
+            "path-is-inside": "1.0.2",
+            "pluralize": "4.0.0",
+            "progress": "2.0.0",
+            "require-uncached": "1.0.3",
+            "semver": "5.4.1",
+            "strip-json-comments": "2.0.1",
+            "table": "4.0.2",
+            "text-table": "0.2.0"
+          }
+        },
+        "eslint-plugin-flowtype": {
+          "version": "2.35.0",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.35.0.tgz",
+          "integrity": "sha512-zjXGjOsHds8b84C0Ad3VViKh+sUA9PeXKHwPRlSLwwSX0v1iUJf/6IX7wxc+w2T2tnDH8PT6B/YgtcEuNI3ssA==",
+          "requires": {
+            "lodash": "4.17.4"
+          }
+        },
+        "eslint-plugin-import": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.7.0.tgz",
+          "integrity": "sha512-HGYmpU9f/zJaQiKNQOVfHUh2oLWW3STBrCgH0sHTX1xtsxYlH1zjLh8FlQGEIdZSdTbUMaV36WaZ6ImXkenGxQ==",
+          "requires": {
+            "builtin-modules": "1.1.1",
+            "contains-path": "0.1.0",
+            "debug": "2.6.9",
+            "doctrine": "1.5.0",
+            "eslint-import-resolver-node": "0.3.1",
+            "eslint-module-utils": "2.1.1",
+            "has": "1.0.1",
+            "lodash.cond": "4.5.2",
+            "minimatch": "3.0.4",
+            "read-pkg-up": "2.0.0"
+          },
+          "dependencies": {
+            "doctrine": {
+              "version": "1.5.0",
+              "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+              "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+              "requires": {
+                "esutils": "2.0.2",
+                "isarray": "1.0.0"
+              }
+            }
+          }
+        },
+        "eslint-plugin-react": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.1.0.tgz",
+          "integrity": "sha1-J3cKzzn1/UnNCvQIPOWBBOs5DUw=",
+          "requires": {
+            "doctrine": "2.0.0",
+            "has": "1.0.1",
+            "jsx-ast-utils": "1.4.1"
+          }
+        },
+        "esprima": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+        },
+        "js-yaml": {
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+          "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+          "requires": {
+            "argparse": "1.0.9",
+            "esprima": "4.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "strip-bom": "3.0.0"
+          }
+        },
+        "path-type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+          "requires": {
+            "pify": "2.3.0"
+          }
+        },
         "promise": {
           "version": "8.0.1",
           "resolved": "https://registry.npmjs.org/promise/-/promise-8.0.1.tgz",
@@ -8577,6 +8321,30 @@
           "requires": {
             "asap": "2.0.6"
           }
+        },
+        "read-pkg": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+          "requires": {
+            "load-json-file": "2.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "2.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+          "requires": {
+            "find-up": "2.1.0",
+            "read-pkg": "2.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
         }
       }
     },
@@ -8881,7 +8649,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-      "dev": true,
       "requires": {
         "caller-path": "0.1.0",
         "resolve-from": "1.0.1"
@@ -8912,8 +8679,7 @@
     "resolve-from": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
-      "dev": true
+      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY="
     },
     "restore-cursor": {
       "version": "2.0.0",
@@ -9180,7 +8946,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
       "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
-      "dev": true,
       "requires": {
         "is-fullwidth-code-point": "2.0.0"
       }
@@ -9313,15 +9078,6 @@
         "wbuf": "1.7.2"
       }
     },
-    "split": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
-      "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
-      "dev": true,
-      "requires": {
-        "through": "2.3.8"
-      }
-    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -9354,15 +9110,6 @@
       "requires": {
         "inherits": "2.0.3",
         "readable-stream": "2.3.3"
-      }
-    },
-    "stream-combiner": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
-      "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
-      "dev": true,
-      "requires": {
-        "duplexer": "0.1.1"
       }
     },
     "stream-http": {
@@ -9537,7 +9284,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
       "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
-      "dev": true,
       "requires": {
         "ajv": "5.3.0",
         "ajv-keywords": "2.1.1",
@@ -9551,7 +9297,6 @@
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
           "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-          "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
@@ -9564,15 +9309,6 @@
       "version": "0.2.8",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.8.tgz",
       "integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI="
-    },
-    "term-size": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
-      "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
-      "dev": true,
-      "requires": {
-        "execa": "0.7.0"
-      }
     },
     "test-exclude": {
       "version": "4.1.1",
@@ -9652,15 +9388,6 @@
       "resolved": "https://registry.npmjs.org/toposort/-/toposort-1.0.6.tgz",
       "integrity": "sha1-wxdI5V0hDv/AD9zcfW5o19e7nOw="
     },
-    "touch": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
-      "integrity": "sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==",
-      "dev": true,
-      "requires": {
-        "nopt": "1.0.10"
-      }
-    },
     "tough-cookie": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
@@ -9687,8 +9414,7 @@
     "tryit": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
-      "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
-      "dev": true
+      "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics="
     },
     "tty-browserify": {
       "version": "0.0.0",
@@ -9729,8 +9455,7 @@
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-      "dev": true
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "ua-parser-js": {
       "version": "0.7.17",
@@ -9790,12 +9515,6 @@
         }
       }
     },
-    "undefsafe": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-0.0.3.tgz",
-      "integrity": "sha1-7Mo6A+VrmvFzhbqsgSrIO5lKli8=",
-      "dev": true
-    },
     "uniq": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
@@ -9813,15 +9532,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
       "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI="
-    },
-    "unique-string": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
-      "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
-      "dev": true,
-      "requires": {
-        "crypto-random-string": "1.0.0"
-      }
     },
     "universalify": {
       "version": "0.1.1",
@@ -10513,7 +10223,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-      "dev": true,
       "requires": {
         "mkdirp": "0.5.1"
       }

--- a/client/package.json
+++ b/client/package.json
@@ -14,12 +14,10 @@
     "eslint-plugin-flowtype": "^2.39.1",
     "eslint-plugin-import": "^2.8.0",
     "eslint-plugin-jsx-a11y": "^5.1.1",
-    "eslint-plugin-react": "^7.5.1",
-    "nodemon": "^1.12.1"
+    "eslint-plugin-react": "^7.5.1"
   },
   "scripts": {
-    "dev": "nodemon --exec \"yarn build && rm -rf ../public && mkdir ../public && cp -R build/ ../public/\"",
-    "buildandcopy": "npm run build && rm -rf ../public && mkdir ../public && cp -R build/ ../public/",
+    "dev": "npm run start",
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",

--- a/client/package.json
+++ b/client/package.json
@@ -17,7 +17,6 @@
     "eslint-plugin-react": "^7.5.1"
   },
   "scripts": {
-    "dev": "npm run start",
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -14,7 +14,7 @@ class App extends Component {
   }
 
   searchData(searchTerms) {
-    const url = '/data?query=' + searchTerms;
+    const url = '/api/data?query=' + searchTerms;
     console.log('Calling url', url);
     console.log('Should be searching with "', searchTerms,'"');
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "yarn": "1.2.1"
   },
   "scripts": {
+    "testprod": "NODE_ENV=production MONGO_URL=mongodb://localhost:27017 npm start",
     "dev": "LOCAL=true nodemon --exec npm start",
     "lint": "eslint .",
     "start": "node ./server/app.js",
@@ -23,7 +24,6 @@
     "moment": "^2.19.1",
     "mongoose": "^4.13.4",
     "node-fetch": "^1.7.3",
-    "node-localstorage": "^1.3.0",
     "serve-favicon": "~2.4.5",
     "underscore": "^1.8.3",
     "xlsx": "^0.11.6"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev": "LOCAL=true nodemon --exec npm start",
     "lint": "eslint .",
     "start": "node ./server/app.js",
-    "build-client": "cd client && npm install && npm run buildandcopy"
+    "build-client": "cd client && npm install && npm run build"
   },
   "dependencies": {
     "bluebird": "^3.5.1",

--- a/server/app.js
+++ b/server/app.js
@@ -33,6 +33,7 @@ function initializeServer() {
 }
 
 app.get('/alldata', (req, res) => {
+app.get('/api/alldata', (req, res) => {
   alkoLoader.getAllDataForDay(moment()).then((result) => {
     console.log('Results are here', result.length);
     res.json(result);
@@ -41,7 +42,7 @@ app.get('/alldata', (req, res) => {
   });
 });
 
-app.get('/data', (req, res) => {
+app.get('/api/data', (req, res) => {
   console.log('Request parameters: ', req.query);
 
   const searchTerms = req.query.query;
@@ -57,7 +58,7 @@ app.get('/data', (req, res) => {
   });
 });
 
-app.get('/refreshdata', (req, res) => {
+app.get('/api/refreshdata', (req, res) => {
   initializeServer();
   res.send('Refreshing.. <a href="/">Back to frontpage</a>');
 });

--- a/server/app.js
+++ b/server/app.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const http = require('http');
 const cors = require('cors');
+const proxy = require('http-proxy-middleware');
 const moment = require('moment');
 const fetch = require('node-fetch');
 const Bluebird = require('bluebird');
@@ -32,7 +33,13 @@ function initializeServer() {
   alkoLoader.getDataForSpecificDay(moment());
 }
 
-app.get('/alldata', (req, res) => {
+if (process.env.NODE_ENV === 'production') {
+  app.use(express.static(`${__dirname}/../client/build`));
+  app.use(/^\/(?!api).*/, express.static(`${__dirname}/../client/build`));
+} else {
+  app.use(/^\/(?!api).*/, proxy({ target: 'http://localhost:3000', changeOrigin: false }));
+}
+
 app.get('/api/alldata', (req, res) => {
   alkoLoader.getAllDataForDay(moment()).then((result) => {
     console.log('Results are here', result.length);
@@ -62,8 +69,6 @@ app.get('/api/refreshdata', (req, res) => {
   initializeServer();
   res.send('Refreshing.. <a href="/">Back to frontpage</a>');
 });
-
-app.use(express.static('public'));
 
 const port = process.env.PORT || 8080;
 app.set('port', port);

--- a/server/app.js
+++ b/server/app.js
@@ -35,7 +35,6 @@ function initializeServer() {
 
 if (process.env.NODE_ENV === 'production') {
   app.use(express.static(`${__dirname}/../client/build`));
-  app.use(/^\/(?!api).*/, express.static(`${__dirname}/../client/build`));
 } else {
   app.use(/^\/(?!api).*/, proxy({ target: 'http://localhost:3000', changeOrigin: false }));
 }


### PR DESCRIPTION
- Add http-proxy-middleware to enable developing with `react-scripts start`.
- Prefix api-routes with /api/
- Static production serve with path `${__dirname}/../client/build`
- Removed nodemon from client deps since it is not used anymore.
- Removed buildandcopy and dev scripts from client package.json since they are not used anymore.
- Minor update to README.md but you should update it for good!